### PR TITLE
Fix lane-change collision; harder ramp; height-scaled spawns

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -1,47 +1,24 @@
 <script>
-  /**
-   * Game Architecture Overview **********************************************
-   *
-   * This is a dual-lane endless runner game built in Svelte where a player
-   * controls two cars simultaneously. Core mechanics:
-   *
-   * - Each side (left/right) has two lanes the car can switch between
-   * - Obstacles spawn from the top and move downward at increasing speed
-   * - Players tap/click left/right side of screen to control respective cars
-   * - Score increases based on circles collected, time survived and speed
-   * - Game ends if either car collides with an obstacle or misses a circle
-   *
-   * The game uses requestAnimationFrame for smooth animation and updates obstacle
-   * positions each frame based on elapsed time and current speed. Collision
-   * detection uses simple radius-based checking between cars and obstacles.
-   *
-   * State management is handled through Svelte's reactive declarations, with the
-   * main game loop updating positions and spawning obstacles based on probability
-   * that increases with score/time.
-   */
-
   import { onMount } from 'svelte';
   import './app.css';
 
-  /**
-   * Configuration ************************************************************
-   */
   const GAME_CONFIG = {
     MAX_WIDTH: 380,
     CAR_OFFSET_Y: 140,
-    MIN_VERTICAL_SPACING: 100,
-    SIDE_MIN_SPACING: 150,
-    CROSS_SIDE_SPACING: 80,
-    BASE_SPAWN_CHANCE: 0.02,
-    SPEED_MULTIPLIER: 0.004,
-    COLLISION_RADIUS: 30,
+    MIN_VERTICAL_SPACING: 92,
+    SIDE_MIN_SPACING: 138,
+    CROSS_SIDE_SPACING: 72,
+    BASE_SPAWN_CHANCE: 0.026,
+    SPEED_MULTIPLIER: 0.0052,
+    REF_H: 560,
+    CAR_HW: 15,
+    CAR_HH: 25,
+    CIRCLE_R: 15,
+    SQUARE_HW: 15,
     LEFT_COLOR: '#f23a63',
     RIGHT_COLOR: '#05aac1'
   };
 
-  /**
-   * Game State ***************************************************************
-   */
   let score = 0;
   let bestScore = parseInt(localStorage.getItem('bestScore')) || 0;
   let gameOver = false;
@@ -52,10 +29,7 @@
   let roadDashOffset = 0;
   let gameHeight, gameWidth, gameContainer;
 
-  /**
-   * Reactive Calculations ****************************************************
-   */
-  $: speed = Math.min(15, 3 + (score * 0.05) + (elapsedTime / 20000));
+  $: speed = Math.min(22, 3 + score * 0.062 + elapsedTime / 14000);
   $: speedDisplay = speed.toFixed(1);
   $: gameWidth = gameContainer ? Math.min(GAME_CONFIG.MAX_WIDTH, gameContainer.clientWidth) : GAME_CONFIG.MAX_WIDTH;
 
@@ -64,28 +38,21 @@
     right: { start: gameWidth * 0.625, alt: gameWidth * 0.88 }
   };
 
-  /**
-   * Game Objects *************************************************************
-   */
   let cars = {
-    left: { lane: 'left', y: 0, x: 0 },
-    right: { lane: 'left', y: 0, x: 0 }
+    left: { lane: 'left', y: 0, x: 0, tx: 0 },
+    right: { lane: 'left', y: 0, x: 0, tx: 0 }
   };
   let obstacles = [];
+  let nextObsId = 0;
 
-  // Update car positions
-  $: {
-    if (gameHeight) {
-      ['left', 'right'].forEach(side => {
-        cars[side].x = cars[side].lane === 'left' ? LANE_POSITIONS[side].start : LANE_POSITIONS[side].alt;
-        cars[side].y = gameHeight - GAME_CONFIG.CAR_OFFSET_Y;
-      });
+  $: if (gameHeight) {
+    for (const side of ['left', 'right']) {
+      const c = cars[side];
+      c.tx = c.lane === 'left' ? LANE_POSITIONS[side].start : LANE_POSITIONS[side].alt;
+      c.y = gameHeight - GAME_CONFIG.CAR_OFFSET_Y;
     }
   }
 
-  /**
-   * Game Controls ************************************************************
-   */
   const toggleCarLane = (side) => (event) => {
     event?.preventDefault();
     if (!isPaused && !gameOver) {
@@ -102,13 +69,10 @@
     controls[event.key]?.();
   };
 
-  /**
-   * Obstacle Management ******************************************************
-   */
   const spawnObstacle = () => {
     if (obstacles.some(obs => obs.y < GAME_CONFIG.MIN_VERTICAL_SPACING)) return;
 
-    const spawnChance = GAME_CONFIG.BASE_SPAWN_CHANCE + (speed - 3) * GAME_CONFIG.SPEED_MULTIPLIER;
+    let spawnChance = (GAME_CONFIG.BASE_SPAWN_CHANCE + (speed - 3) * GAME_CONFIG.SPEED_MULTIPLIER) * Math.min(1.38, 0.82 + gameHeight / GAME_CONFIG.REF_H * 0.45);
     if (Math.random() > spawnChance) return;
 
     const side = Math.random() < 0.5 ? 'left' : 'right';
@@ -124,29 +88,46 @@
     const lane = Math.random() < 0.5 ? 'left' : 'right';
     const x = lane === 'left' ? LANE_POSITIONS[side].start : LANE_POSITIONS[side].alt;
 
-    obstacles = [...obstacles, { x, y: -20, type, side }];
+    obstacles = [...obstacles, { id: nextObsId++, x, y: -22, type, side }];
   };
 
-  const checkCollision = (car, obstacle) =>
-    Math.hypot(car.x - obstacle.x, car.y - obstacle.y) < GAME_CONFIG.COLLISION_RADIUS;
+  const hitCircle = (cx, cy, ox, oy) => {
+    const L = cx - GAME_CONFIG.CAR_HW,
+      T = cy - GAME_CONFIG.CAR_HH,
+      R = cx + GAME_CONFIG.CAR_HW,
+      B = cy + GAME_CONFIG.CAR_HH;
+    const nx = ox < L ? L : ox > R ? R : ox;
+    const ny = oy < T ? T : oy > B ? B : oy;
+    const dx = ox - nx,
+      dy = oy - ny,
+      r = GAME_CONFIG.CIRCLE_R;
+    return dx * dx + dy * dy < r * r;
+  };
 
-  /**
-   * Game Loop ****************************************************************
-   */
+  const hitSquare = (cx, cy, ox, oy) =>
+    Math.abs(cx - ox) < GAME_CONFIG.CAR_HW + GAME_CONFIG.SQUARE_HW &&
+    Math.abs(cy - oy) < GAME_CONFIG.CAR_HH + GAME_CONFIG.SQUARE_HW;
+
   const update = (timestamp) => {
     if (gameOver || isPaused) return;
 
     const deltaTime = timestamp - lastFrameTime;
     lastFrameTime = timestamp;
+    const dt = deltaTime / 16;
+    const laneBlend = 1 - Math.exp(-deltaTime / 165);
     elapsedTime = Date.now() - gameStartTime;
-    roadDashOffset -= speed * (deltaTime / 16);
+    roadDashOffset -= speed * dt;
 
-    // Update obstacles
+    for (const side of ['left', 'right']) {
+      const c = cars[side];
+      c.x += (c.tx - c.x) * laneBlend;
+    }
+
     obstacles = obstacles.filter(obs => {
-      obs.y += speed * (deltaTime / 16);
-      const relevantCar = cars[obs.side];
+      obs.y += speed * dt;
+      const c = cars[obs.side];
 
-      if (checkCollision(relevantCar, obs)) {
+      if (obs.type === 'square' ? hitSquare(c.x, c.y, obs.x, obs.y) : hitCircle(c.x, c.y, obs.x, obs.y)) {
         if (obs.type === 'square') {
           updateBestScore();
           gameOver = true;
@@ -170,9 +151,6 @@
     if (!gameOver) requestAnimationFrame(update);
   };
 
-  /**
-   * Game State Management ****************************************************
-   */
   const updateBestScore = () => {
     if (score > bestScore) {
       bestScore = score;
@@ -192,26 +170,32 @@
     score = 0;
     gameOver = false;
     obstacles = [];
+    nextObsId = 0;
     gameStartTime = Date.now();
     elapsedTime = 0;
     roadDashOffset = 0;
     isPaused = false;
-    cars = {
-      left: { lane: 'left', y: gameHeight - GAME_CONFIG.CAR_OFFSET_Y, x: 0 },
-      right: { lane: 'left', y: gameHeight - GAME_CONFIG.CAR_OFFSET_Y, x: 0 }
-    };
+    cars = { left: { lane: 'left', y: 0, x: 0, tx: 0 }, right: { lane: 'left', y: 0, x: 0, tx: 0 } };
+    for (const side of ['left', 'right']) {
+      const t = cars[side].lane === 'left' ? LANE_POSITIONS[side].start : LANE_POSITIONS[side].alt;
+      cars[side].y = gameHeight - GAME_CONFIG.CAR_OFFSET_Y;
+      cars[side].tx = cars[side].x = t;
+    }
     lastFrameTime = performance.now();
     requestAnimationFrame(update);
   };
 
-  /**
-   * Initialization ***********************************************************
-   */
   onMount(() => {
     const updateHeight = () => {
       if (gameContainer) {
         gameHeight = window.innerHeight;
         gameContainer.style.height = `${gameHeight}px`;
+        for (const side of ['left', 'right']) {
+          const c = cars[side];
+          c.tx = c.lane === 'left' ? LANE_POSITIONS[side].start : LANE_POSITIONS[side].alt;
+          c.y = gameHeight - GAME_CONFIG.CAR_OFFSET_Y;
+          c.x = c.tx;
+        }
       }
     };
 
@@ -257,7 +241,7 @@
 
   <!-- Game Canvas ******************************************************** -->
   <svg width={gameWidth} height={gameHeight}>
-    {#each ['left', 'right'] as side}
+    {#each ['left', 'right'] as side (side)}
       <!-- Lanes -->
       <rect
         x={side === 'left' ? 0 : gameWidth/2}
@@ -304,7 +288,7 @@
     {/each}
 
     <!-- Obstacles -->
-    {#each obstacles as obstacle}
+    {#each obstacles as obstacle (obstacle.id)}
       <g>
         {#if obstacle.type === 'circle'}
           <circle cx={obstacle.x} cy={obstacle.y} r="15" fill={obstacle.side === 'left' ? GAME_CONFIG.LEFT_COLOR : GAME_CONFIG.RIGHT_COLOR} />

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -2,19 +2,22 @@
   /**
    * Game Architecture Overview **********************************************
    *
-   * Dual-lane endless runner in Svelte: two cars (left/right screen halves),
-   * tap or keys to switch lanes. Obstacles spawn from the top; collect circles,
-   * avoid squares. Score rises with pickups; game ends on square hit or missed
-   * circle.
+   * This is a dual-lane endless runner game built in Svelte where a player
+   * controls two cars simultaneously. Core mechanics:
    *
-   * The main loop uses requestAnimationFrame. Lane flips set a target x (tx);
-   * each frame the car x eases toward tx so collision uses the same position as
-   * the SVG (avoids CSS-only motion drifting from logic). Squares use AABB vs
-   * AABB; circles use circle vs axis-aligned car bounds.
+   * - Each side (left/right) has two lanes the car can switch between
+   * - Obstacles spawn from the top and move downward at increasing speed
+   * - Players tap/click left/right side of screen to control respective cars
+   * - Score increases based on circles collected, time survived and speed
+   * - Game ends if either car collides with an obstacle or misses a circle
    *
-   * Spawn rate scales with speed and viewport height (taller viewports get a
-   * modest bump so difficulty stays fair). Reactive statements keep lane pixel
-   * positions in sync when width/height change.
+   * The game uses requestAnimationFrame for smooth animation and updates obstacle
+   * positions each frame based on elapsed time and current speed. Collision
+   * detection uses simple radius-based checking between cars and obstacles.
+   *
+   * State management is handled through Svelte's reactive declarations, with the
+   * main game loop updating positions and spawning obstacles based on probability
+   * that increases with score/time.
    */
 
   import { onMount } from 'svelte';

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -1,7 +1,28 @@
 <script>
+  /**
+   * Game Architecture Overview **********************************************
+   *
+   * Dual-lane endless runner in Svelte: two cars (left/right screen halves),
+   * tap or keys to switch lanes. Obstacles spawn from the top; collect circles,
+   * avoid squares. Score rises with pickups; game ends on square hit or missed
+   * circle.
+   *
+   * The main loop uses requestAnimationFrame. Lane flips set a target x (tx);
+   * each frame the car x eases toward tx so collision uses the same position as
+   * the SVG (avoids CSS-only motion drifting from logic). Squares use AABB vs
+   * AABB; circles use circle vs axis-aligned car bounds.
+   *
+   * Spawn rate scales with speed and viewport height (taller viewports get a
+   * modest bump so difficulty stays fair). Reactive statements keep lane pixel
+   * positions in sync when width/height change.
+   */
+
   import { onMount } from 'svelte';
   import './app.css';
 
+  /**
+   * Configuration ************************************************************
+   */
   const GAME_CONFIG = {
     MAX_WIDTH: 380,
     CAR_OFFSET_Y: 140,
@@ -19,6 +40,9 @@
     RIGHT_COLOR: '#05aac1'
   };
 
+  /**
+   * Game State ***************************************************************
+   */
   let score = 0;
   let bestScore = parseInt(localStorage.getItem('bestScore')) || 0;
   let gameOver = false;
@@ -29,6 +53,9 @@
   let roadDashOffset = 0;
   let gameHeight, gameWidth, gameContainer;
 
+  /**
+   * Reactive Calculations ****************************************************
+   */
   $: speed = Math.min(22, 3 + score * 0.062 + elapsedTime / 14000);
   $: speedDisplay = speed.toFixed(1);
   $: gameWidth = gameContainer ? Math.min(GAME_CONFIG.MAX_WIDTH, gameContainer.clientWidth) : GAME_CONFIG.MAX_WIDTH;
@@ -38,6 +65,9 @@
     right: { start: gameWidth * 0.625, alt: gameWidth * 0.88 }
   };
 
+  /**
+   * Game Objects *************************************************************
+   */
   let cars = {
     left: { lane: 'left', y: 0, x: 0, tx: 0 },
     right: { lane: 'left', y: 0, x: 0, tx: 0 }
@@ -45,6 +75,7 @@
   let obstacles = [];
   let nextObsId = 0;
 
+  // Lane targets (tx) and vertical position from layout; x lerps in update().
   $: if (gameHeight) {
     for (const side of ['left', 'right']) {
       const c = cars[side];
@@ -53,6 +84,9 @@
     }
   }
 
+  /**
+   * Game Controls ************************************************************
+   */
   const toggleCarLane = (side) => (event) => {
     event?.preventDefault();
     if (!isPaused && !gameOver) {
@@ -69,6 +103,9 @@
     controls[event.key]?.();
   };
 
+  /**
+   * Obstacle Management ******************************************************
+   */
   const spawnObstacle = () => {
     if (obstacles.some(obs => obs.y < GAME_CONFIG.MIN_VERTICAL_SPACING)) return;
 
@@ -91,6 +128,9 @@
     obstacles = [...obstacles, { id: nextObsId++, x, y: -22, type, side }];
   };
 
+  /**
+   * Collision (car center cx,cy vs obstacle center ox,oy) **********************
+   */
   const hitCircle = (cx, cy, ox, oy) => {
     const L = cx - GAME_CONFIG.CAR_HW,
       T = cy - GAME_CONFIG.CAR_HH,
@@ -108,6 +148,9 @@
     Math.abs(cx - ox) < GAME_CONFIG.CAR_HW + GAME_CONFIG.SQUARE_HW &&
     Math.abs(cy - oy) < GAME_CONFIG.CAR_HH + GAME_CONFIG.SQUARE_HW;
 
+  /**
+   * Game Loop ****************************************************************
+   */
   const update = (timestamp) => {
     if (gameOver || isPaused) return;
 
@@ -151,6 +194,9 @@
     if (!gameOver) requestAnimationFrame(update);
   };
 
+  /**
+   * Game State Management ****************************************************
+   */
   const updateBestScore = () => {
     if (score > bestScore) {
       bestScore = score;
@@ -185,6 +231,9 @@
     requestAnimationFrame(update);
   };
 
+  /**
+   * Initialization ***********************************************************
+   */
   onMount(() => {
     const updateHeight = () => {
       if (gameContainer) {

--- a/src/app.css
+++ b/src/app.css
@@ -106,6 +106,13 @@ body {
 
 
 /**
+ * Car motion *****************************************************************
+ * Horizontal easing runs in the game loop (lerp toward target lane), not CSS,
+ * so collision uses the same x as the SVG. No transition on .car here.
+ */
+
+
+/**
  * Touch controls *************************************************************
  */
 .touch-left, .touch-right {

--- a/src/app.css
+++ b/src/app.css
@@ -106,22 +106,6 @@ body {
 
 
 /**
- * Animation classes **********************************************************
- */
-.car, g {
-  transition: transform 0.2s ease-out;
-}
-
-.car {
-  transition: x 0.2s ease-out, cx 0.2s ease-out, transform 0.2s ease-out;
-}
-
-g {
-  transform-origin: center;
-}
-
-
-/**
  * Touch controls *************************************************************
  */
 .touch-left, .touch-right {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- **Hit detection:** The car’s horizontal position is now smoothed in the game loop toward the target lane (`tx`), and collisions use that same `x`. This matches what you see on screen and fixes false “hits” when the old logic snapped `x` instantly while CSS animated the rects.
- **Shapes:** Squares use axis-aligned box overlap with the car body; circles use circle-vs-AABB (closest point), which is tighter than a single center-distance radius for rectangles.
- **Difficulty:** Higher top speed (`Math.min(22, …)`), faster ramp from score/time, slightly higher base spawn and multiplier, and spawn chance scaled up on taller viewports (`gameHeight / REF_H`). Spacing values tweaked slightly so more can fit.
- **Size:** Removed unused CSS transition blocks; kept logic compact. Production `dist/index.html` is ~16.8 kB raw / ~6.8 kB gzip in this environment.
- **Docs:** Restored the original-style file header and section banner comments in `App.svelte`, updated for lerped positions and collision; added a short note in `app.css` where car transitions used to live.

## Testing

- `npm run build`
- Svelte autofixer (no issues; optional suggestion about `bind:this` unchanged)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8f7ed7e8-e22f-4cf8-9023-aac307d46c3f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8f7ed7e8-e22f-4cf8-9023-aac307d46c3f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

